### PR TITLE
Improve writing throughput

### DIFF
--- a/cubeide-sd-card/FATFS/Target/user_diskio_spi.c
+++ b/cubeide-sd-card/FATFS/Target/user_diskio_spi.c
@@ -132,9 +132,7 @@ void xmit_spi_multi (
 	UINT btx			/* Number of bytes to send (even number) */
 )
 {
-	for(UINT i=0; i<btx; i++) {
-		xchg_spi(*(buff+i));
-	}
+	HAL_SPI_Transmit(&SD_SPI_HANDLE, buff, btx, 100);
 }
 #endif
 

--- a/cubeide-sd-card/FATFS/Target/user_diskio_spi.c
+++ b/cubeide-sd-card/FATFS/Target/user_diskio_spi.c
@@ -132,7 +132,7 @@ void xmit_spi_multi (
 	UINT btx			/* Number of bytes to send (even number) */
 )
 {
-	HAL_SPI_Transmit(&SD_SPI_HANDLE, buff, btx, 100);
+	HAL_SPI_Transmit(&SD_SPI_HANDLE, buff, btx, HAL_MAX_DELAY);
 }
 #endif
 


### PR DESCRIPTION
Fix #19 : use the Transmit Hal instead of calling TransmitReceive in a loop.

I have a tested that it does improve throughput. Something equivalent could be done to the `rcvr_spi_multi` by doing something like `memset(buff, 0xFF, btr); HAL_SPI_Receive(&SD_SPI_HANDLE, (BYTE*)buff, btr, 100);`. I tested it and it does not break the software. I think it should improve throughput on read but I did not verify it. I might do a benchmark at a later point and do another pull request if results show an improvement.